### PR TITLE
fix: add error message parameter to Wait.until function

### DIFF
--- a/src/main/kotlin/io/iohk/atala/automation/utils/Wait.kt
+++ b/src/main/kotlin/io/iohk/atala/automation/utils/Wait.kt
@@ -26,8 +26,8 @@ object Wait {
     fun until(
         timeout: Duration = 5.seconds,
         pollInterval: Duration = 500.milliseconds,
+        errorMessage: String? = null,
         condition: () -> Boolean,
-        errorMessage: String?,
     ) {
         try {
             Awaitility.await()


### PR DESCRIPTION
Add capability to specify error message if waiting finished with timeout